### PR TITLE
Update Contract Creation

### DIFF
--- a/content/1. Ethereum101/Contract Creation.md
+++ b/content/1. Ethereum101/Contract Creation.md
@@ -1,10 +1,12 @@
 # 42 - [Contract Creation](Contract%20Creation.md)
 
-Contract creation transactions are sent to a special destination address called the zero address i.e. `0x0`. 
+When creating a contract from an externally owned account (EOA), you set the "to" value to "null" or "0x0" or just leave it empty. This is to indicate that this transaction is not directed at a specific address but is instead a contract creation transaction.
 
 A contract creation transaction contains a data payload with the compiled bytecode to create the contract. 
 
 An optional ether amount in the [Value](Value.md) field will create the new contract with a starting balance.
+
+
 
 ___
 ## Slide Screenshot
@@ -12,7 +14,7 @@ ___
 ___
 ## Slide Text
 - Tx Result -> Creation [Transaction](Transaction.md)
-- Create tx -> Sent to special 0 address (0x0)
+- Create tx -> Sent to "null", "0x0" or empty
 - Data Payload -> Contract Bytecode
 - Value -> Optional Starting Contract Ether Balance
  ___


### PR DESCRIPTION
Hi, just a small suggestion here, the "zero address" is super confusing because it seems that it means the actual 20 bytes zero address "address(0)" in solidity. As you know, a contract creation does not occur when the "to" address is set to the actual address(0), rather it gets executed when the "to" value is set to null, left empty or the "0x0". I know that the intention was to mean the "0x0" value but it is still confusing and a lot of new developers mistakenly think that creating a contract is by sending a transaction to the 0 address.  

I think it is important to be more precise with this subject.

From the solidity docs: 
"If the target account is not set (the transaction does not have a recipient or the recipient is set to null), the transaction creates a new contract."
link: https://docs.soliditylang.org/en/v0.8.19/introduction-to-smart-contracts.html#index-8